### PR TITLE
Fix g++/clang build

### DIFF
--- a/VkCppGenerator.cpp
+++ b/VkCppGenerator.cpp
@@ -225,7 +225,7 @@ std::string const optionalClassHeader = (
 "\n"
 "  private:\n"
 "    Optional(std::nullptr_t) { m_ptr = nullptr; }\n"
-"    friend typename RefType;\n"
+"    friend RefType;\n"
 "    RefType *m_ptr;\n"
 "  };\n"
 "\n"


### PR DESCRIPTION
This `typename` produces the following error:

```
vk_cpp.h:197:21: error: expected nested-name-specifier before ‘RefType’
     friend typename RefType;
                     ^
```
